### PR TITLE
fix: widen package version range to avoid "Unsupported engine" warning

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "Ed Jones"
   ],
   "engines": {
-    "node": "18.12.1"
+    "node": ">=18.12.1"
   },
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
:wave: Hey, thank you for creating this project! It's been super helpful to me and I've been using it for a while now.

I've made some changes to the package version to address the "Unsupported engine" warning that kept popping up. Specifically, I widened the version range and tested it with versions 18.x and 19.x, and everything seems to be working smoothly.

In addition, I noticed that this package should also be compatible with nodejs versions 14.x and 16.x, but I understand if you don't want to officially support those versions.

Thank you for taking the time to review my pull request. I hope these changes are helpful and improve the project even more.