### PR TITLE
fix: :bug: add declaration map to tsconfig

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,7 +14,9 @@
 		"resolveJsonModule": true,
 		"isolatedModules": true,
 		"noEmit": true,
-		"jsx": "react-jsx"
+		"jsx": "react-jsx",
+		"declaration": true,
+		"declarationMap": true
 	},
 	"include": ["src"],
 	"references": [{ "path": "./tsconfig.node.json" }]


### PR DESCRIPTION
Adding a declaration map allows for editors to go straight to the source code rather than the declaration files when command clicking.