### PR TITLE
feat: Expose MaterialSymbolWeight, SymbolCodepoints interfaces

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,6 +1,7 @@
 import type { ElementType, CSSProperties, ReactElement, Ref } from 'react';
 import { forwardRef } from 'react';
 import type { MaterialSymbolWeight, PolymorphicComponentProps, SymbolCodepoints } from './types';
+export type { MaterialSymbolWeight, SymbolCodepoints } from './types';
 import { combineClasses } from './utils';
 
 export type MaterialSymbolProps = {


### PR DESCRIPTION
Hi and thanks for the library. I'm working a project that has a dependency on react-material-symbols, and we're switching to ES modules.

Previously, we could do something like
```tsx
import { SymbolCodepoints } from "react-material-symbols/dist/types";
```

but not anymore. I tried doing
```tsx
import { MaterialSymbolProps } from "react-material-symbols";

export type SymbolCodepoints = MaterialSymbolProps["icon"]
```

but the resultant type is `any` strangely, maybe because of the sheer size of the union? I've opened this PR so you can get at these types directly.