### PR TITLE
feat: Use CSS variables for `font-variation-settings`

### DIFF
--- a/public/common.css
+++ b/public/common.css
@@ -2,7 +2,7 @@
 	user-select: none;
 	font-weight: normal;
 	font-style: normal;
-	font-size: inherit;
+	font-size: var(--material-symbols-size-px, inherit);
 	display: inline-block;
 	line-height: 1;
 	text-transform: none;
@@ -10,4 +10,9 @@
 	word-wrap: normal;
 	white-space: nowrap;
 	direction: ltr;
+	font-variation-settings: "FILL" var(--material-symbols-fill, 0), "GRAD" var(--material-symbols-grad, 0), "opsz" max(var(--material-symbols-size, 20), 20);
+}
+
+.material-symbols[data-weight] {
+	font-variation-settings: "FILL" var(--material-symbols-fill, 0), "GRAD" var(--material-symbols-grad, 0), "opsz" max(var(--material-symbols-size, 20), 20), "wght" var(--material-symbols-weight);
 }

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -4,6 +4,11 @@ import type { MaterialSymbolWeight, PolymorphicComponentProps, SymbolCodepoints 
 export type { MaterialSymbolWeight, SymbolCodepoints } from './types';
 import { combineClasses } from './utils';
 
+export const MATERIAL_SYMBOL_FILL_VAR = "--material-symbols-fill";
+export const MATERIAL_SYMBOL_GRAD_VAR = "--material-symbols-grad";
+export const MATERIAL_SYMBOL_SIZE_VAR = "--material-symbols-size";
+export const MATERIAL_SYMBOL_WEIGHT_VAR = "--material-symbols-weight";
+
 export type MaterialSymbolProps = {
 	/** Required. The name of the icon to render. */
 	icon: SymbolCodepoints;
@@ -50,25 +55,19 @@ export const MaterialSymbol = forwardRef(
 		ref: Ref<C>
 	): ReactElement => {
 		const Component = onClick !== undefined ? 'button' : (as as ElementType) ?? 'span';
-		const style = { color, ...propStyle };
+		const style = { color, "--material-symbols-size-px": "calc(var(--material-symbols-size) * 1px)", ...propStyle };
 
 		if (fill)
-			style.fontVariationSettings = [style.fontVariationSettings, '"FILL" 1']
-				.filter(Boolean)
-				.join(', ');
+			(style as Record<string, unknown>)[MATERIAL_SYMBOL_FILL_VAR] = 1;
 		if (weight)
-			style.fontVariationSettings = [style.fontVariationSettings, `"wght" ${weight}`]
-				.filter(Boolean)
-				.join(', ');
+			// When weight is supplied, we also set the `data-weight` attribute
+			// so that we can switch to the CSS rule that specifies the "wght"
+			// font variation axis.
+			(style as Record<string, unknown>)[MATERIAL_SYMBOL_WEIGHT_VAR] = weight;
 		if (grade)
-			style.fontVariationSettings = [style.fontVariationSettings, `"GRAD" ${grade}`]
-				.filter(Boolean)
-				.join(', ');
+			(style as Record<string, unknown>)[MATERIAL_SYMBOL_GRAD_VAR] = grade;
 		if (size) {
-			style.fontVariationSettings = [style.fontVariationSettings, `"opsz" ${size}`]
-				.filter(Boolean)
-				.join(', ');
-			style.fontSize = size;
+			(style as Record<string, unknown>)[MATERIAL_SYMBOL_SIZE_VAR] = size;
 		}
 
 		return (
@@ -78,6 +77,7 @@ export const MaterialSymbol = forwardRef(
 				style={style}
 				onClick={onClick}
 				className={combineClasses('material-symbols', className)}
+				{...(weight && { "data-weight": true})}
 			>
 				{icon}
 			</Component>


### PR DESCRIPTION
This PR tweaks the component so that the props are applied using CSS variables instead of the `style` attribute. The idea is

- clients can adjust these styles in their CSS without needing `!important` to get around the specificity of `style`
- clients can use the exported CSS variable names to implement e.g. "all Material Symbols of this component default to size 16px", while still getting optical sizing. Or "all Material Symbols of this component become filled when this pseudo-class is present" etc